### PR TITLE
add event binding

### DIFF
--- a/src/jssocials.js
+++ b/src/jssocials.js
@@ -169,7 +169,7 @@
 
             for (var key in share.on){
                 var bindFunction = share.on[key];
-                if ($.isFunction(bindFunction) {
+                if ($.isFunction(bindFunction)) {
                     $result.on(key, bindFunction);
                 }
             }

--- a/src/jssocials.js
+++ b/src/jssocials.js
@@ -167,6 +167,13 @@
                 .attr({ href: this._getShareUrl(share), target: "_blank" })
                 .append(this._createShareLogo(share));
 
+            for (var key in share.on){
+                var bindFunction = share.on[key];
+                if ($.isFunction(bindFunction) {
+                    $result.on(key, bindFunction);
+                }
+            }
+
             if(this._showLabel) {
                 $result.append(this._createShareLabel(share));
             }


### PR DESCRIPTION
Enable data binding in extra option "on".

i.e.:

```javascript
//facebook sharing in popup
{
    share: "facebook",
    on: {
        click: function (e) {
            e.preventDefault();
            var url = $(this).attr('href');
            window.open(url,
                        'facebook ',
                        'height=320, width=640, toolbar=no, menubar=no, scrollbars=no, resizable=no, location=no, directories=no, status=no');
        },
        mouseenter: function (e) {
            console.log('Enter in facebook icon');
        }
    }
}
//email sharing without open window
{
    share: "email",
    logo: 'fa fa-envelope',
    on: {
        click: function (e) {
            e.preventDefault();
            var url = $(this).attr('href');
            var $iframe = $('<iframe>', {src: url, style: "display: none;" });
            $iframe.load(function () {
                $iframe.remove();
            });
            $('body').append($iframe);
        }
    }
}
```