### PR TITLE
Removing Twitter urls count

### DIFF
--- a/src/jssocials.shares.js
+++ b/src/jssocials.shares.js
@@ -13,10 +13,7 @@
             label: "Tweet",
             logo: "fa fa-twitter",
             shareUrl: "https://twitter.com/share?url={url}&text={text}&via={via}&hashtags={hashtags}",
-            countUrl: "https://cdn.api.twitter.com/1/urls/count.json?url={url}&callback=?",
-            getCount: function(data) {
-                return data.count;
-            }
+            countUrl: ""
         },
 
         facebook: {


### PR DESCRIPTION
The urls count endpoint is no longer available. (Since 20th November)

https://blog.twitter.com/2015/hard-decisions-for-a-sustainable-platform