### PR TITLE
Add _self to email sharing, avoid empty page

### DIFF
--- a/src/jssocials.shares.js
+++ b/src/jssocials.shares.js
@@ -24,7 +24,8 @@
             label: "E-mail",
             logo: "fa fa-at",
             shareUrl: "mailto:{to}?subject={text}&body={url}",
-            countUrl: ""
+            countUrl: "",
+            target: "_self"
         },
 
         twitter: {


### PR DESCRIPTION
Hi, small improvement now that we have the target = _self possibility.
Because email on a desktop acts like whatsapp on a mobile (trigger external app), the user is faced with an empty tab / page when returning after sending the mail.
Setting the target for email to _self does not open a new tab / page but just calls the email application. After returning the user is returned to the page he/she pressed the email button on.

I think that this should also be set for the Line button, but I do not now the Line network / app so cannot test.