### PR TITLE
counturl facebook broken on httpS sites

### DIFF
--- a/src/jssocials.shares.js
+++ b/src/jssocials.shares.js
@@ -21,7 +21,7 @@
             label: "Like",
             logo: "fa fa-facebook",
             shareUrl: "https://facebook.com/sharer/sharer.php?u={url}",
-            countUrl: "http://graph.facebook.com/?id={url}",
+            countUrl: "//graph.facebook.com/?id={url}",
             getCount: function(data) {
                 return data.share && data.share.share_count || 0;
             }


### PR DESCRIPTION
Hi, could not get my head around the fact that on some sites the facebook count url was not showing up... it turned out that these sites where httpS sites. By omitting the http the correct one (http or https) will automatically be selected and the counter works again :)

Needs testing to confirm :)