### PR TITLE
Fix alignment of buttons on multi-row display

### DIFF
--- a/styles/jssocials.scss
+++ b/styles/jssocials.scss
@@ -13,11 +13,7 @@ $external-margin: .2em 0 !default;
 .jssocials-share {
     display: inline-block;
     vertical-align: top;
-    margin: $base-padding;
-}
-
-.jssocials-share:first-child {
-    margin-left: 0;
+    margin: $base-padding 2*$base-padding $base-padding 0;
 }
 
 .jssocials-share:last-child {


### PR DESCRIPTION
Now that there are a lot of buttons that can be displayed we run into the issue that the buttons will be displayed on multiple lines.
This PR fixes the incorrect margin of the buttons on the 2nd, 3rd, etc. line.
See before and after image
![selection_028](https://cloud.githubusercontent.com/assets/2733197/18580350/6b51fe44-7bfb-11e6-925b-68e40e64975d.png)
![selection_027](https://cloud.githubusercontent.com/assets/2733197/18580351/6b54ca0c-7bfb-11e6-9e78-230f0873d9db.png)
