### PR TITLE
Fix margin right of shares with counts and label are disabled. 

### DIFF
--- a/dist/jssocials.css
+++ b/dist/jssocials.css
@@ -7,7 +7,7 @@
 .jssocials-share {
   display: inline-block;
   vertical-align: top;
-  margin: 0.3em 0.6em 0.3em 0; }
+  margin: 0.3em 0.3em 0.3em 0; }
 
 .jssocials-share:last-child {
   margin-right: 0; }


### PR DESCRIPTION
### Problem
When I rendered the Jssocial on the page, I see problem of margin mismatch between 2nd and 3rd and so on elements of the shares. 

### Fix
I changed the margin right to match with the rest of the icons to make it consistent. 

### Configuration 
With the following configuration, I am having `margin-right` issue which I have added an image to indicate also. 



```
 $(selector).jsSocials({
        shares: [
        {share: "facebook", label: "Share"},
        {share: "twitter", text: title, url: short_url},
        {share: "googleplus"},
        {share: "pinterest", media: media}
       ],
        url: url,
        showCount: false,
        showLabel: false,
        shareIn: "popup"

    });
```
### Screenshot
<img width="279" alt="screen shot 2016-10-21 at 11 38 24 am" src="https://cloud.githubusercontent.com/assets/4252738/19589016/0a867498-9783-11e6-84e3-ea2d587a12ae.png">

See the difference of the margin between facebook and twitter and twitter and Google plus.
I was able to fix it by setting the `margin: 0.3em 0.3em 0.3em 0; ` here. 
https://github.com/tabalinas/jssocials/blob/0ea13a483f9a9781b7339a875f5feacf7ae18b74/dist/jssocials.css#L10


I am using `JSSocial==1.4.0`
