### PR TITLE
Add RSS Feed support

### DIFF
--- a/src/jssocials.shares.js
+++ b/src/jssocials.shares.js
@@ -118,6 +118,13 @@
             shareUrl: "fb-messenger://share?link={url}",
             countUrl: "",
             shareIn: "self"
+        },
+        rss: {
+            label: "RSS",
+            logo: "fa fa-rss",
+            shareUrl: "/feeds/",
+            countUrl: "",
+            shareIn: "blank"
         }
 
     });

--- a/styles/_shares.scss
+++ b/styles/_shares.scss
@@ -1,3 +1,3 @@
-$share-names: ('twitter', 'facebook', 'googleplus', 'linkedin', 'pinterest', 'email', 'stumbleupon', 'whatsapp', 'telegram', 'line', 'viber', 'pocket', 'messenger', 'vkontakte') !default;
-$share-colors: (#00aced, #3b5998, #dd4b39, #007bb6, #cb2027, #3490F3, #eb4823, #29a628, #2ca5e0, #25af00, #7b519d, #ef4056, #0084ff, #45668e) !default;
+$share-names: ('twitter', 'facebook', 'googleplus', 'linkedin', 'pinterest', 'email', 'stumbleupon', 'whatsapp', 'telegram', 'line', 'viber', 'pocket', 'messenger', 'vkontakte', 'rss') !default;
+$share-colors: (#00aced, #3b5998, #dd4b39, #007bb6, #cb2027, #3490F3, #eb4823, #29a628, #2ca5e0, #25af00, #7b519d, #ef4056, #0084ff, #45668e, #ff9900) !default;
 


### PR DESCRIPTION
### Add RSS support button for JSSOCIAL.

We needed a RSS feed button the page, why using other button when you already have JsSocial plugin.

### Screenshot
<img width="380" alt="screen shot 2016-10-22 at 4 36 56 pm" src="https://cloud.githubusercontent.com/assets/4252738/19620488/dabc69e6-9897-11e6-96bb-cec78c03273b.png">
<img width="246" alt="screen shot 2016-10-22 at 4 37 08 pm" src="https://cloud.githubusercontent.com/assets/4252738/19620489/daf323b4-9897-11e6-976b-ed80b4b54dfb.png">


### Note
By default it will use `/feeds/` url, if you want to overwirte, provide the following configuration.
```
var rssUrl = '/new/feed/url';
var shareableItems = [
        {share: "googleplus"},
        {share: "rss", shareUrl: rssUrl}
    ];

$('#share').jsSocials({
        shares: shareableItems,
        shareIn: "popup",
});
```