### PR TITLE
Add Facebook Messenger Browser + SMS sharing support

### DIFF
--- a/src/jssocials.shares.js
+++ b/src/jssocials.shares.js
@@ -95,6 +95,14 @@
             shareIn: "top"
         },
 
+        browser_messenger: {
+            label: "Share",
+            logo: "fa fa-commenting",
+            shareUrl: "https://www.facebook.com/dialog/send?app_id={appid}&link={url}&redirect_uri={redirect}",
+            countUrl: "",
+            shareIn: "top"
+        },
+
         telegram: {
             label: "Telegram",
             logo: "fa fa-telegram",

--- a/src/jssocials.shares.js
+++ b/src/jssocials.shares.js
@@ -133,6 +133,15 @@
             logo: "fa fa-rss",
             shareUrl: "/feeds/",
             countUrl: ""
+        },
+
+	sms: {
+            label: "SMS",
+            logo: "fa fa-comments-o",
+            shareUrl: "sms:{delimiter}body={text} {url}",
+            delimiter: "?",
+            countUrl: "",
+            shareIn: "top"
         }
 
     });

--- a/styles/_shares.scss
+++ b/styles/_shares.scss
@@ -1,3 +1,3 @@
-$share-names: ('twitter', 'facebook', 'googleplus', 'linkedin', 'pinterest', 'email', 'stumbleupon', 'whatsapp', 'telegram', 'line', 'viber', 'pocket', 'messenger', 'browser_messenger', 'vkontakte', 'rss') !default;
-$share-colors: (#00aced, #3b5998, #dd4b39, #007bb6, #cb2027, #3490F3, #eb4823, #29a628, #2ca5e0, #25af00, #7b519d, #ef4056, #0084ff, #0084ff, #45668e, #ff9900) !default;
+$share-names: ('twitter', 'facebook', 'googleplus', 'linkedin', 'pinterest', 'email', 'stumbleupon', 'whatsapp', 'telegram', 'line', 'viber', 'pocket', 'messenger', 'browser_messenger', 'vkontakte', 'rss', 'sms') !default;
+$share-colors: (#00aced, #3b5998, #dd4b39, #007bb6, #cb2027, #3490F3, #eb4823, #29a628, #2ca5e0, #25af00, #7b519d, #ef4056, #0084ff, #0084ff, #45668e, #ff9900, #ffbd00) !default;
 

--- a/styles/_shares.scss
+++ b/styles/_shares.scss
@@ -1,3 +1,3 @@
-$share-names: ('twitter', 'facebook', 'googleplus', 'linkedin', 'pinterest', 'email', 'stumbleupon', 'whatsapp', 'telegram', 'line', 'viber', 'pocket', 'messenger', 'vkontakte', 'rss') !default;
-$share-colors: (#00aced, #3b5998, #dd4b39, #007bb6, #cb2027, #3490F3, #eb4823, #29a628, #2ca5e0, #25af00, #7b519d, #ef4056, #0084ff, #45668e, #ff9900) !default;
+$share-names: ('twitter', 'facebook', 'googleplus', 'linkedin', 'pinterest', 'email', 'stumbleupon', 'whatsapp', 'telegram', 'line', 'viber', 'pocket', 'messenger', 'browser_messenger', 'vkontakte', 'rss') !default;
+$share-colors: (#00aced, #3b5998, #dd4b39, #007bb6, #cb2027, #3490F3, #eb4823, #29a628, #2ca5e0, #25af00, #7b519d, #ef4056, #0084ff, #0084ff, #45668e, #ff9900) !default;
 


### PR DESCRIPTION
Hi,

This change facilitates browser support for Facebook Messenger.
At first Facebook messenger had an app (Android / iOS), but currently it is also possible to share via the browser (messenger).

I have prepended browser_ this way it (should be) is clear that messenger button this is for browser support.
This naming convention can also be used on e.g. whatsapp, there is already a browser (web) version of whatsapp available.

It is then up to the user to either display messenger (on mobile / tablet) or browser_messenger (on desktop).
My Joomla plugin can handle this via mobile_detect :)

Is this a good strategy to handle the browser versions?

PLUS
Also included is SMS sharing support.
SMS sharing uses a {delimiter} variable that defaults to "?" (all android devices = 85% market share!)
For iOS <= 8 the delimiter should be ";"
For iOS > 8 the delimiter should be "&"

It is up to the user to detect the iOS version and pass the correct delimiter.
