### PR TITLE
Improve {delimiter} parsing

### DIFF
--- a/src/jssocials.js
+++ b/src/jssocials.js
@@ -278,7 +278,7 @@
         _formatShareUrl: function(url, share) {
             return url.replace(URL_PARAMS_REGEX, function(match, key, field) {
                 var value = share[field] || "";
-                return value ? field == "delimiter" ? value : (key || "") + window.encodeURIComponent(value) : "";
+                return value ? field === "delimiter" ? value : (key || "") + window.encodeURIComponent(value) : "";
             });
         },
 

--- a/src/jssocials.js
+++ b/src/jssocials.js
@@ -278,7 +278,7 @@
         _formatShareUrl: function(url, share) {
             return url.replace(URL_PARAMS_REGEX, function(match, key, field) {
                 var value = share[field] || "";
-                return value ? (key || "") + window.encodeURIComponent(value) : "";
+                return value ? field == "delimiter" ? value : (key || "") + window.encodeURIComponent(value) : "";
             });
         },
 


### PR DESCRIPTION
Hi,
this was a hard one to tackle. Apparently there are a lot of sms apps that can be installed on your phone.
As it turned out the SMS button didn't work correct for these apps > they prefilled the contact with the url of the page you where sharing.
It turned out that the root cause for this was that the {delimiter} value got encoded. When not encoding this value all is fine.

This change excludes the {delimiter}  value from being encoded :)