### PR TITLE
Fix window.open windowName

### DIFF
--- a/src/jssocials.js
+++ b/src/jssocials.js
@@ -405,7 +405,7 @@
         popup: function(args) {
             return $("<a>").attr("href", "#")
                 .on("click", function() {
-                    window.open(args.shareUrl, null, "width=600, height=400, location=0, menubar=0, resizeable=0, scrollbars=0, status=0, titlebar=0, toolbar=0");
+                    window.open(args.shareUrl, "", "width=600, height=400, location=0, menubar=0, resizeable=0, scrollbars=0, status=0, titlebar=0, toolbar=0");
                     return false;
                 });
         },


### PR DESCRIPTION
Hi,
null as windowName works, but not in all use cases. when e.g. sharing via Google+ and you are not logged into your google account, opening the popup will windowName = null will open the popup, login to google+ but then the window closes (as there is no name to return to), so you can login but cannot share...
Setting the windowName to "" fixes this faulty behavior, you can now login to google in your popup and after loggin in, the popup stays open and allows you to share the page :)