### PR TITLE
Added missing title variable

### DIFF
--- a/src/jssocials.js
+++ b/src/jssocials.js
@@ -78,6 +78,7 @@
         _initDefaults: function() {
             this.url = window.location.href;
             this.text = $.trim($("meta[name=description]").attr("content") || $(document).prop("title"));
+			this.title =$("title").text();
         },
 
         _initShares: function() {
@@ -92,7 +93,7 @@
                     throw Error("Share '" + shareConfig.share + "' is not found");
                 }
 
-                return $.extend({ url: this.url, text: this.text }, share, shareConfig);
+                return $.extend({ url: this.url, text: this.text, title: this.title }, share, shareConfig);
             }, this));
         },
 


### PR DESCRIPTION
In the original version of jssocial, I found that the title variable was missing from shareurls that were supposed to have it. I checked the code, but couldn't find the title variable defined anywhere, so I've added it.

This is my first pull request ever (I'm nervous!) I have read the contributing notes.
I've not done the grunt tests, but I've run github/jssocials/test/jssocials.html 
Everything passed except for **share rendering: set custom handlers with 'on'**, but I think it is to be expected in this case. Here are the results of that test.

```
Expected:  
{
  "share": "testshare",
  "shareUrl": "http://test.com/share/",
  "text": "testtext",
  "url": "testurl"
}

Result: 	
{
  "share": "testshare",
  "shareUrl": "http://test.com/share/",
  "text": "testtext",
  "title": "jsSocials Test Suite",
  "url": "testurl"
}

Diff: 	
 {
   "share":  "testshare",
   "shareUrl":  "http://test.com/share/",
   "text":  "testtext",
   "title": "jsSocials Test Suite",
   "url":  "testurl"
 } 
```
I've tested a different branch (that contained the above changes) on my server and the title variable was correctly added to the url.

If I've gone about this pull request incorrectly, made any mistakes or you have any feedback, I'd love to hear it. Thanks!
 